### PR TITLE
fix ble display old name after rename

### DIFF
--- a/esp-now/esp-mesh-bluetooth/src/main.cpp
+++ b/esp-now/esp-mesh-bluetooth/src/main.cpp
@@ -284,6 +284,9 @@ void OnDataRecv(const uint8_t *mac, const uint8_t *incomingData, int len) {
         case UPDATE_DEVICE_NAME:
           Serial.printf("update device name: %s\n\n", payload.name);
           DEVICE_NAME = payload.name;
+           esp_ble_gap_set_device_name(DEVICE_NAME.c_str());       
+           BLEDevice::getAdvertising()->stop();
+           BLEDevice::getAdvertising()->start();
           saveJson();
         break;
         case UPDATE_DEVICE_ID:


### PR DESCRIPTION
added method esp_ble_gap_set_device_name and restart advertsing to change the device of ble

**Is this a patch, a minor version change, or a major version change**
minor

**Is this related to an open issue?**
https://github.com/open-horizon-services/service-liquid-prep/issues/56
Bluetooth connection still shows the old name after rename 

